### PR TITLE
Updated User-Agent to be set in the headers by default

### DIFF
--- a/lib/net/dav.rb
+++ b/lib/net/dav.rb
@@ -130,6 +130,8 @@ module Net #:nodoc:
             Net::HTTP::Proppatch.new(path)
 	  when :lock
             Net::HTTP::Lock.new(path)
+          when :unlock
+            Net::HTTP::Unlock.new(path)
           else
             raise "unkown verb #{verb}"
           end


### PR DESCRIPTION
The WebDAV spec requires the User-Agent to be set in the headers for all requests. This change adds a default header for when the request function is called without passing in any headers.
