### PR TITLE
Bugfix: Headers in Net::DAV not always correctly filled in

### DIFF
--- a/lib/net/dav.rb
+++ b/lib/net/dav.rb
@@ -355,7 +355,7 @@ module Net #:nodoc:
       @uri = uri
       @uri = URI.parse(@uri) if @uri.is_a? String
       @handler = @have_curl ? CurlHandler.new(@uri) : NetHttpHandler.new(@uri)
-      @headers = options[:headers] rescue {}
+      @headers = options && options[:headers] ? options[:headers] : {}
     end
 
     # Opens the connection to the host.  Yields self to the block.


### PR DESCRIPTION
The Net::DAV initializer doesn't set the headers correctly: If an options hash is provided without a :headers key, it fails. This commit fixes that.
