### PR TITLE
Content-Type for NetHttpHandler#request_sending_* methods looks wrong

### DIFF
--- a/lib/net/dav.rb
+++ b/lib/net/dav.rb
@@ -74,7 +74,7 @@ module Net #:nodoc:
         req.body_stream = stream
         req.content_length = length
         headers.each_pair { |key, value| req[key] = value } if headers
-        req.content_type = 'text/xml; charset="utf-8"'
+        req.content_type = 'application/octet-stream'
         res = handle_request(req, headers)
         res
       end
@@ -91,7 +91,7 @@ module Net #:nodoc:
           end
         req.body = body
         headers.each_pair { |key, value| req[key] = value } if headers
-        req.content_type = 'text/xml; charset="utf-8"'
+        req.content_type = 'application/octet-stream'
         res = handle_request(req, headers)
         res
       end


### PR DESCRIPTION
The content type is set to text/xml. This causes some webservers (e.g. WEBrick) try to parse the body as XML. I've changed it to octet-stream, which seems the safest option.
