### PR TITLE
Add field Net::DAV#last_status the last http status

### DIFF
--- a/spec/integration/net_dav_spec.rb
+++ b/spec/integration/net_dav_spec.rb
@@ -22,6 +22,13 @@ describe "Net::Dav" do
     @props.should match(/200 OK/)
   end
 
+  it "should store the HTTP status in @status" do
+    dav = Net::DAV.new("http://localhost:10080/")
+    @props = dav.propfind("/").to_s
+
+    dav.last_status.should == 207
+  end
+
   it "should raise if finding non-existent path" do
     dav = Net::DAV.new("http://localhost:10080/")
     lambda do
@@ -44,6 +51,7 @@ describe "Net::Dav" do
     @props.should match(/404.*Not found/i)
 
     dav.put_string("/new_file.html","File contents")
+    dav.last_status.should == 200
 
     @props = find_props_or_error(dav, "/new_file.html")
     @props.should match(/200 OK/i)
@@ -56,8 +64,11 @@ describe "Net::Dav" do
      @props.should match(/200 OK/i)
 
      dav.delete("/new_file.html")
+     dav.last_status.should == 204
+
      @props = find_props_or_error(dav, "/new_file.html")
      @props.should match(/404.*Not found/i)
+
    end
 
   it "should copy files on webdav server" do
@@ -67,6 +78,8 @@ describe "Net::Dav" do
     @props.should match(/200 OK/i)
 
     dav.copy("/file.html","/copied_file.html")
+    dav.last_status.should == 201
+
     @props = find_props_or_error(dav, "/copied_file.html")
     @props.should match(/200 OK/i)
 
@@ -83,6 +96,8 @@ describe "Net::Dav" do
     @props.should match(/200 OK/i)
 
     dav.move("/file.html","/moved_file.html")
+    dav.last_status.should == 201
+
     @props = find_props_or_error(dav, "/moved_file.html")
     @props.should match(/200 OK/i)
 


### PR DESCRIPTION
Since we want to use net_dav for integration testing, I've added a field #last_status that contains the last http status, so I can read the server status even if no exceptions occur.
