### PR TITLE
Use a case-insensitive regex when checking for Basic auth header.

### DIFF
--- a/lib/net/dav.rb
+++ b/lib/net/dav.rb
@@ -179,7 +179,7 @@ module Net #:nodoc:
           response.error! unless @user
           response.error! if req['authorization']
           new_req = clone_req(req.path, req, headers)
-          if response['www-authenticate'] =~ /^Basic/
+          if response['www-authenticate'] =~ /^basic/i
             if disable_basic_auth
               raise "server requested basic auth, but that is disabled"
             end


### PR DESCRIPTION
While HTTP header values are probably case-sensitive (though I haven't found a reference for that), I've encountered a server that returns "BASIC ..." when looking for basic auth. I've modified the regex to be more lenient in that regard.
