### PR TITLE
Password is returned after calling Net::DAV#credentials

### DIFF
--- a/lib/net/dav.rb
+++ b/lib/net/dav.rb
@@ -398,6 +398,10 @@ module Net #:nodoc:
     def credentials(user, pass)
       @handler.user = user
       @handler.pass = pass
+
+      # Return something explicitly since this command might be run in a
+      # console where the last statement would be printed.
+      nil
     end
 
     # Set extra headers for the dav request


### PR DESCRIPTION
Hi,

When I'm using net_dav from an IRB session, my password is printed after calling #credentials. I added an explicit last statement to the method to prevent that.
