### PR TITLE
Set the content-type to the retry request.

### DIFF
--- a/lib/net/dav.rb
+++ b/lib/net/dav.rb
@@ -179,6 +179,7 @@ module Net #:nodoc:
         new_req.body = req.body if req.body
         new_req.body_stream = req.body_stream if req.body_stream
         headers.each_pair { |key, value| new_req[key] = value } if headers
+        new_req.content_type = new_req.content_type if new_req.content_type
         return new_req
       end
 


### PR DESCRIPTION
We need to set the content type on the retry request. Otherwise when
we get an authorization required response the content type is set to
something else by probably some underlyig library which causes
funnines.

fixes devrandom/net_dav#3
