### PR TITLE
Support relative redirects

### DIFF
--- a/lib/net/dav.rb
+++ b/lib/net/dav.rb
@@ -190,6 +190,12 @@ module Net #:nodoc:
           return handle_request(req, headers, limit - 1, &block)
         when Net::HTTPRedirection then
           location = URI.parse(response['location'])
+
+          # Support relative redirects, where they are of the format of /blah/
+          location.scheme ||= @uri.scheme
+          location.host ||= @uri.host
+          location.port ||= @uri.port
+
           if (@uri.scheme != location.scheme ||
               @uri.host != location.host ||
               @uri.port != location.port)


### PR DESCRIPTION
One particular WebDAV software has generated a relative redirect,
which is not currently supported. Support it by setting the
scheme, host, and port to the existing @uri if they are nil.
