### PR TITLE
Add the require statement to the README Usage part

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -14,7 +14,8 @@ If you're having install issues with nokogiri on Mac OS X read
 http://wiki.github.com/tenderlove/nokogiri/what-to-do-if-libxml2-is-being-a-jerk
 
 == Usage
-
+  require 'net/dav'
+  
   Net::DAV.start("https://localhost.localdomain/xyz/") { |dav|
     find('.', :recursive => true) do | item |
        item.content = item.content.gsub(/silly/i, "funny")


### PR DESCRIPTION
It's quite obvious how this is required as soon as you know the module structure of this gem. But as a service to the fellow users this adds it to the demo part of the README. To save some people a little time searching. 🕐 